### PR TITLE
Added handling of missing values to bdi_compute_sum

### DIFF
--- a/R/bdi_functions.R
+++ b/R/bdi_functions.R
@@ -2,16 +2,49 @@
 #'
 #' @param data Data containing BDI data
 #' @param cols Columns that contain BDI data
+#' @param max_missing Maximum number of components allowed to be missing. Defaults
+#' to \code{NULL}, which means that any missing component counts as 0. Hence, 
+#' if all BDI components are missing, the sum is still 0, not \code{NA}.
 #'
 #' @return numeric
 #' @export
 #' @family bdi_functions
 #' @importFrom dplyr enquo select matches
-bdi_compute_sum = function(data, cols = matches("BDI_[0-9][0-9]$")){
+#' @examples 
+#' # Example of treatment of missing values
+#' library(dplyr)
+#' library(Questionnaires)
+#' data <- tibble(
+#' BDI_01 = c(1, NA_real_, NA_real_, 2, 1),
+#' BDI_02 = c(1, 1, NA_real_, 2, NA_real_)
+#' )
+#' 
+#' # Row with all components missing, gets sum 0
+#' data %>% 
+#'   bind_cols(BDI_sum = bdi_compute_sum(data))
+#' # Do not allow any missing values
+#' data %>% 
+#'   bind_cols(BDI_sum = bdi_compute_sum(data, max_missing = 0))
+#' # Allow one missing value
+#' data %>% 
+#'   bind_cols(BDI_sum = bdi_compute_sum(data, max_missing = 2))
+#' 
+bdi_compute_sum = function(data, cols = matches("BDI_[0-9][0-9]$"), max_missing = NULL){
   cols = enquo(cols)
   
   # If raw BDI is punched, calculate the sum
-  rowSums(select(data, !!cols), na.rm=T)
+  if(is.null(max_missing)){
+    rowSums(select(data, !!cols), na.rm = TRUE)  
+  } else {
+    stopifnot(max_missing >= 0)
+    apply(select(data, !!cols), 1, function(x){
+      if(sum(is.na(x)) > max_missing){
+        NA_real_
+      } else {
+        sum(x, na.rm = TRUE)
+      }
+    })
+  }
   
 }
 

--- a/man/bdi_compute_sum.Rd
+++ b/man/bdi_compute_sum.Rd
@@ -4,18 +4,43 @@
 \alias{bdi_compute_sum}
 \title{Calculate sum of BDI}
 \usage{
-bdi_compute_sum(data, cols = matches("BDI_[0-9][0-9]$"))
+bdi_compute_sum(data, cols = matches("BDI_[0-9][0-9]$"),
+  max_missing = NULL)
 }
 \arguments{
 \item{data}{Data containing BDI data}
 
 \item{cols}{Columns that contain BDI data}
+
+\item{max_missing}{Maximum number of components allowed to be missing. Defaults
+to \code{NULL}, which means that any missing component counts as 0. Hence, 
+if all BDI components are missing, the sum is still 0, not \code{NA}.}
 }
 \value{
 numeric
 }
 \description{
 Calculate sum of BDI
+}
+\examples{
+# Example of treatment of missing values
+library(dplyr)
+library(Questionnaires)
+data <- tibble(
+BDI_01 = c(1, NA_real_, NA_real_, 2, 1),
+BDI_02 = c(1, 1, NA_real_, 2, NA_real_)
+)
+
+# Row with all components missing, gets sum 0
+data \%>\% 
+  bind_cols(BDI_sum = bdi_compute_sum(data))
+# Do not allow any missing values
+data \%>\% 
+  bind_cols(BDI_sum = bdi_compute_sum(data, max_missing = 0))
+# Allow one missing value
+data \%>\% 
+  bind_cols(BDI_sum = bdi_compute_sum(data, max_missing = 2))
+
 }
 \seealso{
 Other bdi_functions: \code{\link{bdi_compute}},


### PR DESCRIPTION
For the Lifebrain sleep analysis, I needed to set the sum to NA rather than 0 when the participants have not answered any question. Thus proposing this as a general extension of the package, rather than writing my own custom code.